### PR TITLE
Fix hero spacing on tall mobile screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
 
     .hero {
       padding-top: 12em;
-      padding-bottom: 4em;
+      padding-bottom: 6em;
     }
 
     .full-logo {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -171,7 +171,7 @@ body, html {
 
 .hero {
   padding-top: 12em;
-  padding-bottom: 4em;
+  padding-bottom: 6em;
 }
 
 .full-logo {
@@ -239,7 +239,7 @@ iframe {
   }
 
   #home {
-    margin-bottom: 4em;
+    margin-bottom: 6em;
   }
 
   .glass-box,


### PR DESCRIPTION
## Summary
- adjust hero bottom padding
- provide extra margin under the home section for smaller screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68466025bf4c83269798c09c12c91490