### PR TITLE
Adjust mobile hero spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,6 +305,8 @@
     </div>
   </section>
 
+  <div class="spacer-mobile"></div>
+
   <section id="about" class="section">
     <div class="glass-box wide">
       <h2>Our Mission</h2>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -174,6 +174,11 @@ body, html {
   padding-bottom: 6em;
 }
 
+/* Spacer element used only on mobile */
+.spacer-mobile {
+  display: none;
+}
+
 .full-logo {
   width: 700px;
   max-width: 95vw;
@@ -239,7 +244,19 @@ iframe {
   }
 
   #home {
-    margin-bottom: 6em;
+    margin-bottom: 0;
+  }
+
+  .hero {
+    min-height: 100vh;
+    padding-top: 8em;
+    padding-bottom: 2em;
+    justify-content: center;
+  }
+
+  .spacer-mobile {
+    display: block;
+    height: 2em;
   }
 
   .glass-box,


### PR DESCRIPTION
## Summary
- improve mobile layout spacing
- show a spacer element so the about section appears after the hero

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846619a26a08326aafa7687bb4b970d