### PR TITLE
Adjust header opacity

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       top: 0;
       width: 100%;
       z-index: 1000;
-      background: rgba(255, 255, 255, 0.65);
+      background: rgba(255, 255, 255, 0.85);
       backdrop-filter: blur(10px);
       box-shadow: 0 2px 10px rgba(0,0,0,0.1);
     }
@@ -121,7 +121,7 @@
       position: fixed;
       top: calc(60px + 1.5rem);
       left: 1rem;
-      background: rgba(255, 255, 255, 0.65);
+      background: rgba(255, 255, 255, 0.85);
       backdrop-filter: blur(12px);
       padding: 1rem;
       border-radius: 15px;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -36,7 +36,7 @@ body, html {
   width: 95%;
   max-width: 1100px;
   z-index: 1000;
-  background: rgba(255, 255, 255, 0.45);
+  background: rgba(255, 255, 255, 0.85);
   backdrop-filter: blur(10px);
   box-shadow: 0 2px 10px rgba(0,0,0,0.1);
   border-radius: 20px;
@@ -129,7 +129,7 @@ body, html {
   position: fixed;
   top: calc(60px + 1.5rem);
   left: 1rem;
-  background: rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.85);
   backdrop-filter: blur(8px);
   padding: 1rem;
   border-radius: 15px;


### PR DESCRIPTION
## Summary
- make the frosted header and mobile menu backgrounds whiter
- restore original background overlay opacity

## Testing
- `git log -2 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846de12bb3c8326afc84b3be7253dae