### PR TITLE
Fix hero overlap on iPad portrait

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -197,6 +197,8 @@ body, html {
 .hero {
   padding-top: 12em;
   padding-bottom: 6em;
+  min-height: 100vh;
+  justify-content: center;
 }
 
 /* Spacer element used only on mobile */


### PR DESCRIPTION
## Summary
- keep the hero section full screen so content below starts further down

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846effc752c83268b15ed2a3dcad473