### PR TITLE
Fix hero layout in landscape mode

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -25,6 +25,7 @@ body, html {
   background: rgba(255, 255, 255, 0.45);
   backdrop-filter: blur(6px);
   z-index: 0;
+  min-height: 100svh;
 }
 
 /* Fixed Header */
@@ -197,8 +198,15 @@ body, html {
 .hero {
   padding-top: 12em;
   padding-bottom: 6em;
-  min-height: 100vh;
+  min-height: 100svh;
   justify-content: center;
+}
+
+@media (orientation: landscape) and (max-height: 500px) {
+  .hero {
+    padding-top: 6em;
+    padding-bottom: 2em;
+  }
 }
 
 /* Spacer element used only on mobile */
@@ -275,7 +283,7 @@ iframe {
   }
 
   .hero {
-    min-height: 100vh;
+    min-height: 100svh;
     padding-top: 8em;
     padding-bottom: 2em;
     justify-content: center;


### PR DESCRIPTION
## Summary
- update overlay height
- adjust hero min-height to account for mobile browser UI
- add landscape rule for tight vertical space

## Testing
- `grep -n "100vh" -n styles/styles.css`

------
https://chatgpt.com/codex/tasks/task_e_6846f34025e883269b8e664b5df78331