### PR TITLE
Fix mobile nav orientation

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -287,7 +287,7 @@ iframe {
 }
 
 /* Responsive Design */
-@media (max-width: 768px) {
+@media (max-width: 768px), (pointer: coarse) and (orientation: landscape) {
   .frosted-header {
     display: none;
   }


### PR DESCRIPTION
## Summary
- update responsive media query to keep mobile nav active when devices are in landscape orientation

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6846f69c395083269e57c6c628f48e69