### PR TITLE
Improve service carousel layout

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -94,6 +94,10 @@ function updateCarousel(index) {
   mainImg.src = services[currentService].src;
   mainImg.alt = services[currentService].title;
   serviceTitle.textContent = services[currentService].title;
+  mainImg.classList.add('spin');
+  mainImg.addEventListener('animationend', () => {
+    mainImg.classList.remove('spin');
+  }, { once: true });
   styleThumbnails();
   centerThumbnail();
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -353,13 +353,20 @@ iframe {
   margin: 0 auto 1.5em;
   border-radius: 25px;
   overflow: hidden;
+  aspect-ratio: 16 / 9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  perspective: 1000px;
 }
 
 
 .main-service-img {
-  display: block;
+  position: absolute;
+  inset: 0;
   width: 100%;
-  height: auto;
+  height: 100%;
+  object-fit: cover;
   border-radius: 25px;
 }
 
@@ -418,6 +425,8 @@ iframe {
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: none;
+  margin: 0 auto;
+  width: 100%;
 }
 
 .thumbnail-carousel::-webkit-scrollbar {
@@ -436,4 +445,13 @@ iframe {
 .thumbnail-carousel img.selected {
   transform: scale(1.2);
   opacity: 1;
+}
+
+.main-service-img.spin {
+  animation: spin 0.6s ease;
+}
+
+@keyframes spin {
+  from { transform: rotateY(0); }
+  to { transform: rotateY(360deg); }
 }


### PR DESCRIPTION
## Summary
- center the service carousel within the glass panel
- ensure all main service images keep the same aspect ratio
- animate the image with a spin transition when changing services

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684700f50b28832696014f95d8ecdf14