### PR TITLE
Add fade animation to services carousel

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -89,12 +89,26 @@ function centerThumbnail() {
 }
 
 function updateCarousel(index) {
-  currentService = (index + services.length) % services.length;
-  mainImg.src = services[currentService].src;
-  mainImg.alt = services[currentService].title;
-  serviceTitle.textContent = services[currentService].title;
-  styleThumbnails();
-  centerThumbnail();
+  const newIndex = (index + services.length) % services.length;
+  if (newIndex === currentService) return;
+
+  mainImg.classList.add('fade-out');
+  serviceTitle.classList.add('fade-out');
+
+  mainImg.addEventListener('transitionend', function handler() {
+    mainImg.removeEventListener('transitionend', handler);
+    currentService = newIndex;
+    mainImg.src = services[currentService].src;
+    mainImg.alt = services[currentService].title;
+    serviceTitle.textContent = services[currentService].title;
+    styleThumbnails();
+    centerThumbnail();
+
+    requestAnimationFrame(() => {
+      mainImg.classList.remove('fade-out');
+      serviceTitle.classList.remove('fade-out');
+    });
+  }, { once: true });
 }
 
 prevBtn.addEventListener('click', () => updateCarousel(currentService - 1));

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -368,6 +368,7 @@ iframe {
   height: 100%;
   object-fit: cover;
   border-radius: 25px;
+  transition: opacity 0.5s ease;
 }
 
 .service-title {
@@ -378,6 +379,12 @@ iframe {
   font-weight: 600;
   color: #fff;
   text-shadow: 0 1px 3px rgba(0,0,0,0.6);
+  transition: opacity 0.5s ease;
+}
+
+.main-service-img.fade-out,
+.service-title.fade-out {
+  opacity: 0;
 }
 
 .carousel-btn {


### PR DESCRIPTION
## Summary
- animate main service image and title when switching services
- apply fade styles for smoother transitions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684705b6eb6c8326b6afde12fc242ded