### PR TITLE
Fix carousel initial visibility

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -115,4 +115,14 @@ prevBtn.addEventListener('click', () => updateCarousel(currentService - 1));
 nextBtn.addEventListener('click', () => updateCarousel(currentService + 1));
 
 renderThumbnails();
+
+// Position thumbnails immediately without animation
+const initialThumbs = thumbContainer.querySelectorAll('img');
+initialThumbs.forEach(img => img.classList.add('initial')); // disable transitions
+styleThumbnails();
+centerThumbnail();
+requestAnimationFrame(() => {
+  initialThumbs.forEach(img => img.classList.remove('initial'));
+});
+
 updateCarousel(0);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -456,3 +456,40 @@ iframe {
 .thumbnail-carousel img.selected {
   opacity: 1;
 }
+
+/* Disable transition on initial load */
+.thumbnail-carousel img.initial {
+  transition: none;
+}
+
+@media (max-width: 768px) {
+  .service-title {
+    font-size: 1.5rem;
+  }
+
+  .carousel-btn {
+    width: 32px;
+    height: 32px;
+  }
+
+  .carousel-btn::before {
+    width: 10px;
+    height: 10px;
+  }
+}
+
+@media (max-width: 480px) {
+  .service-title {
+    font-size: 1.2rem;
+  }
+
+  .carousel-btn {
+    width: 28px;
+    height: 28px;
+  }
+
+  .carousel-btn::before {
+    width: 8px;
+    height: 8px;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure carousel thumbnails are positioned without a startup animation
- style service title and navigation buttons responsively

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6847073ed77c8326b31659b990faf6f2