### PR TITLE
Show thumbnail titles and animate captions

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -383,13 +383,16 @@ iframe {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   font-weight: 600; /* or 500 */
   letter-spacing: 0.2px;
-  transition: opacity 0.5s ease;
+  transition: opacity 0.5s ease, transform 0.5s ease;
 }
 
-.main-service-img.fade-out,
+.main-service-img.fade-out {
+  opacity: 0;
+}
+
 .service-title.fade-out {
   opacity: 0;
-
+  transform: translateY(10px);
 }
 
 .carousel-btn {
@@ -467,14 +470,17 @@ iframe {
   white-space: nowrap;
   color: #333;
   pointer-events: none;
+  opacity: 0.6;
+  transition: transform 0.6s ease, opacity 0.6s ease;
 }
 
+/* Keep title visible for selected thumbnail */
 .thumbnail.selected {
   opacity: 1;
 }
 
 .thumbnail.selected .thumbnail-title {
-  display: none;
+  opacity: 1;
 }
 
 /* Disable transition on initial load */


### PR DESCRIPTION
## Summary
- keep the selected thumbnail's caption visible
- fade/slide the main service title when switching images
- fade thumbnail captions and animate them with their thumbnails

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684709d27e0483268f39fedcf92ec354