### PR TITLE
Fix mobile carousel width and update controls

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -63,12 +63,7 @@ function renderThumbnails() {
     img.src = service.src;
     img.alt = service.title;
 
-    const label = document.createElement('div');
-    label.className = 'thumbnail-title';
-    label.textContent = service.title;
-
     wrapper.appendChild(img);
-    wrapper.appendChild(label);
     thumbContainer.appendChild(wrapper);
   });
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -417,8 +417,8 @@ iframe {
   display: block;
   width: 12px;
   height: 12px;
-  border-left: 2px solid rgba(0,0,0,0.6);
-  border-bottom: 2px solid rgba(0,0,0,0.6);
+  border-left: 2px solid rgba(255,255,255,0.85);
+  border-bottom: 2px solid rgba(255,255,255,0.85);
   transform: rotate(45deg);
 }
 
@@ -461,25 +461,8 @@ iframe {
   border-radius: 10px;
 }
 
-.thumbnail-title {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 0.75rem;
-  white-space: nowrap;
-  color: #333;
-  pointer-events: none;
-  opacity: 0.6;
-  transition: transform 0.6s ease, opacity 0.6s ease;
-}
-
-/* Keep title visible for selected thumbnail */
+/* Highlight selected thumbnail */
 .thumbnail.selected {
-  opacity: 1;
-}
-
-.thumbnail.selected .thumbnail-title {
   opacity: 1;
 }
 
@@ -491,6 +474,10 @@ iframe {
 @media (max-width: 768px) {
   .service-title {
     font-size: 1.5rem;
+  }
+
+  .services-pane {
+    max-width: 100%;
   }
 
   .carousel-btn {
@@ -507,6 +494,10 @@ iframe {
 @media (max-width: 480px) {
   .service-title {
     font-size: 1.2rem;
+  }
+
+  .services-pane {
+    max-width: 100%;
   }
 
   .carousel-btn {


### PR DESCRIPTION
## Summary
- keep service carousel within its glass pane on small screens
- change carousel arrow color to white
- remove thumbnail labels from carousel

## Testing
- `grep -R "test" -n | head`

------
https://chatgpt.com/codex/tasks/task_e_684714ec5ba88326978c2c2a4c195e31